### PR TITLE
review fixups: gitsigns keymaps, which-key groups, dot --quick

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -16,15 +16,17 @@ displayUsageAndExit() {
 	echo "Usage: dot [options]"
 	echo ""
 	echo "Options:"
-	echo "  -e, --edit    Open dotfiles directory for editing"
-	echo "  -h, --help    Show this help message and exit"
+	echo "  -e, --edit     Open dotfiles directory for editing"
+	echo "  -q, --quick    Skip git pull and brew update/upgrade (just relink + run installers)"
+	echo "  -h, --help     Show this help message and exit"
 	exit
 }
 
 break_line() {
-	echo "\n"
+	print ""
 }
 
+QUICK=false
 while test $# -gt 0; do
 	case "$1" in
 		"-h"|"--help")
@@ -34,6 +36,9 @@ while test $# -gt 0; do
 			exec "$EDITOR" "$DOTFILES"
 			exit
 			;;
+		"-q"|"--quick")
+			QUICK=true
+			;;
 		*)
 			echo "Invalid option: $1"
 			displayUsageAndExit
@@ -42,15 +47,17 @@ while test $# -gt 0; do
 	shift
 done
 
-dotlog "info" "Pulling latest from origin/main"
-git -C "$DOTFILES" fetch origin main
-if git -C "$DOTFILES" status --porcelain | grep -q .; then
-	dotlog "info" "Local changes detected — rebasing onto origin/main"
-	git -C "$DOTFILES" rebase origin/main
-else
-	git -C "$DOTFILES" merge --ff-only origin/main
+if [[ "$QUICK" != "true" ]]; then
+	dotlog "info" "Pulling latest from origin/main"
+	git -C "$DOTFILES" fetch origin main
+	if git -C "$DOTFILES" status --porcelain | grep -q .; then
+		dotlog "info" "Local changes detected — rebasing onto origin/main"
+		git -C "$DOTFILES" rebase origin/main
+	else
+		git -C "$DOTFILES" merge --ff-only origin/main
+	fi
+	break_line
 fi
-break_line
 
 if ! [[ $LINUX || $WIN ]]; then
 	dotlog "info" "Set macOS defaults"
@@ -62,26 +69,28 @@ if ! [[ $LINUX || $WIN ]]; then
 	break_line
 fi
 
-# Install and update Homebrew (works on macOS and Linux)
-dotlog "info" "Install homebrew"
-"$DOTFILES/homebrew/install.sh" 2>&1
-break_line
-
-if command -v brew &>/dev/null; then
-	BREW_BIN="$(command -v brew)"
-
-	dotlog "info" "Upgrade homebrew"
-	dotlog "info" "brew update"
-	"$BREW_BIN" update
+if [[ "$QUICK" != "true" ]]; then
+	# Install and update Homebrew (works on macOS and Linux)
+	dotlog "info" "Install homebrew"
+	"$DOTFILES/homebrew/install.sh" 2>&1
 	break_line
 
-	dotlog "info" "brew upgrade"
-	"$BREW_BIN" upgrade
-	break_line
+	if command -v brew &>/dev/null; then
+		BREW_BIN="$(command -v brew)"
 
-	dotlog "info" "brew cleanup"
-	"$BREW_BIN" cleanup
-	break_line
+		dotlog "info" "Upgrade homebrew"
+		dotlog "info" "brew update"
+		"$BREW_BIN" update
+		break_line
+
+		dotlog "info" "brew upgrade"
+		"$BREW_BIN" upgrade
+		break_line
+
+		dotlog "info" "brew cleanup"
+		"$BREW_BIN" cleanup
+		break_line
+	fi
 fi
 
 dotlog "info" "Install software"

--- a/nvim/CHEATSHEET.md
+++ b/nvim/CHEATSHEET.md
@@ -115,16 +115,51 @@ In Telescope: type to filter, `Enter` to open, `Esc` to close.
 
 ### Which-Key (Keybinding Help)
 
-Press `Space` and wait — a popup shows all available keybindings.
+Press `Space` and wait — a popup shows all available keybindings, grouped by prefix:
+
+| Prefix           | Group                                    |
+|------------------|------------------------------------------|
+| `Space f`        | find (telescope)                         |
+| `Space h`        | hunks (git)                              |
+| `Space c`        | code                                     |
+| `Space r`        | rename                                   |
+| `Space w`        | workspace                                |
+| `Space d`        | diagnostics / document                   |
 
 ### Git Signs
 
 Git change indicators appear in the sign column (left gutter) for tracked files.
 
-| Key              | Action                           |
-|------------------|----------------------------------|
-| `] c`            | Next changed hunk                |
-| `[ c`            | Previous changed hunk            |
+| Key              | Action                                   |
+|------------------|------------------------------------------|
+| `] c`            | Next changed hunk                        |
+| `[ c`            | Previous changed hunk                    |
+| `Space h s`      | Stage hunk (works on visual range too)   |
+| `Space h r`      | Reset hunk (works on visual range too)   |
+| `Space h S`      | Stage entire buffer                      |
+| `Space h R`      | Reset entire buffer                      |
+| `Space h p`      | Preview hunk in a floating window        |
+| `Space h b`      | Blame current line (full)                |
+| `Space h d`      | Diff current file against index          |
+| `Space h D`      | Diff current file against last commit    |
+| `Space h t`      | Toggle inline blame for current line     |
+| `i h`            | Text object: "inside hunk" (e.g. `d i h`)|
+
+### LSP (active when a language server attaches)
+
+| Key              | Action                                   |
+|------------------|------------------------------------------|
+| `K`              | Hover documentation                      |
+| `g d`            | Go to definition                         |
+| `g D`            | Go to declaration                        |
+| `g r`            | References (Telescope)                   |
+| `g I`            | Go to implementation                     |
+| `g y`            | Go to type definition                    |
+| `Space r n`      | Rename symbol                            |
+| `Space c a`      | Code action                              |
+| `Space d`        | Buffer diagnostics (Telescope)           |
+| `Space d s`      | Document symbols (Telescope)             |
+| `Space w s`      | Workspace symbols (Telescope)            |
 
 ### Auto Features (just work)
 

--- a/nvim/lua/plugins/gitsigns.lua
+++ b/nvim/lua/plugins/gitsigns.lua
@@ -1,5 +1,50 @@
 return {
   "lewis6991/gitsigns.nvim",
   event = { "BufReadPost", "BufNewFile" },
-  opts = {},
+  opts = {
+    on_attach = function(bufnr)
+      local gs = require("gitsigns")
+      local function map(mode, lhs, rhs, desc)
+        vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, desc = desc })
+      end
+
+      map("n", "]c", function()
+        if vim.wo.diff then
+          vim.cmd.normal({ "]c", bang = true })
+        else
+          gs.nav_hunk("next")
+        end
+      end, "Next hunk")
+
+      map("n", "[c", function()
+        if vim.wo.diff then
+          vim.cmd.normal({ "[c", bang = true })
+        else
+          gs.nav_hunk("prev")
+        end
+      end, "Previous hunk")
+
+      map("n", "<leader>hs", gs.stage_hunk, "Stage hunk")
+      map("n", "<leader>hr", gs.reset_hunk, "Reset hunk")
+      map("v", "<leader>hs", function()
+        gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
+      end, "Stage hunk")
+      map("v", "<leader>hr", function()
+        gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
+      end, "Reset hunk")
+      map("n", "<leader>hS", gs.stage_buffer, "Stage buffer")
+      map("n", "<leader>hR", gs.reset_buffer, "Reset buffer")
+      map("n", "<leader>hp", gs.preview_hunk, "Preview hunk")
+      map("n", "<leader>hb", function()
+        gs.blame_line({ full = true })
+      end, "Blame line")
+      map("n", "<leader>hd", gs.diffthis, "Diff this")
+      map("n", "<leader>hD", function()
+        gs.diffthis("~")
+      end, "Diff this ~")
+      map("n", "<leader>ht", gs.toggle_current_line_blame, "Toggle line blame")
+
+      map({ "o", "x" }, "ih", "<cmd>Gitsigns select_hunk<cr>", "Inside hunk")
+    end,
+  },
 }

--- a/nvim/lua/plugins/whichkey.lua
+++ b/nvim/lua/plugins/whichkey.lua
@@ -4,6 +4,11 @@ return {
   opts = {
     spec = {
       { "<leader>f", group = "find" },
+      { "<leader>h", group = "hunks (git)" },
+      { "<leader>w", group = "workspace" },
+      { "<leader>c", group = "code" },
+      { "<leader>r", group = "rename" },
+      { "<leader>d", group = "diagnostics/docs" },
     },
   },
 }

--- a/system/aliases.zsh
+++ b/system/aliases.zsh
@@ -24,7 +24,7 @@ fi
 # bat overrides for cat
 if command -v bat &>/dev/null
 then
-  alias cat="bat"
+  alias cat="bat --paging=never"
 fi
 
 


### PR DESCRIPTION
- wire gitsigns on_attach with ]c/[c hunk nav and <leader>h{s,r,S,R,p,b,d,D,t} actions (cheatsheet referenced these but they were unbound)
- register which-key groups for <leader>{h,w,c,r,d}
- fix bin/dot break_line() — zsh echo doesn't interpret \n; use print ""
- add -q/--quick flag to bin/dot to skip git pull and brew update/upgrade
- alias cat="bat --paging=never" so pipelines don't hit the pager
- refresh CHEATSHEET with new gitsigns + LSP keymaps and which-key groups